### PR TITLE
Be sure $user has a value even if run as root

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,9 @@ define macdefaults($domain, $key, $value = false, $type = 'string', $action = 'w
   if $runas != 'root' {
     $user = $::current_user
   }
+  else {
+    $user = 'root'
+  }
 
   if $currenthost {
     $writecommand = '/usr/bin/defaults -currentHost write'


### PR DESCRIPTION
Currently, puppet will show a warning if runas is 'root' since $user is not populated. 

To preserve compatibility, this is a bit of an ugly fix to address this without renaming the module's parameter.