### PR TITLE
grep regex sometimes false positive

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,14 +35,14 @@ define macdefaults($domain, $key, $value = false, $type = 'string', $action = 'w
         'write': {
           exec { "${writecommand} ${domain} ${key} -${type} '${value}'":
             user   => $user,
-            unless => "${readcommand} ${domain} ${key} | /usr/bin/grep -q '${grep}'"
+            unless => "${readcommand} ${domain} ${key} | /usr/bin/grep -q '^${grep}$'"
           }
         }
         'delete': {
           exec { "${deletecommand} ${domain} ${key}":
             logoutput => false,
             user      => $user,
-            onlyif    => "${readcommand} ${domain} | /usr/bin/grep -q '${key}'"
+            onlyif    => "${readcommand} ${domain} | /usr/bin/grep -q '^${key}$'"
           }
         }
         default: {


### PR DESCRIPTION
Hi,

while setting DSBindTimeout I realised the grep doesn't make sure the $value is exclusive.
Setting the value to 5 doesn't apply because DSBindTimeout was set to 15 and the grep said it was true, because there was a 5.

Just a little regex to prevent this mistake.

Edit:
Thanks for this simple but great working Module! 